### PR TITLE
ci(fix/docs): skip building `ext_mod` when install workspaces in docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,11 @@ jobs:
           git fetch origin gh-pages --depth=1
       - name: Deploy docs
         env:
-            DOC_TAG: ${{ steps.version_tag.outputs.major && steps.version_tag.outputs.minor && format('{0}.{1} latest', steps.version_tag.outputs.major, steps.version_tag.outputs.minor) || 'dev' }}
+          DOC_TAG: ${{ steps.version_tag.outputs.major && steps.version_tag.outputs.minor && format('{0}.{1} latest', steps.version_tag.outputs.major, steps.version_tag.outputs.minor) || 'dev' }}
+          # skip building pytauri extension module file, see `python/pytauri-wheel/setup.py`
+          # (because we don't need running these workspaces python packages when building docs,
+          # and we don't have tauri system dependencies in the Linux CI)
+          PYTAURI_STANDALONE: 1
         run: |
           uv run --only-group=docs --only-group=workspaces --all-extras -- \
               mike deploy --push --update-aliases ${{ env.DOC_TAG }}


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

follow #108 

# Checklist

- [ ] I've read `CONTRIBUTING.md`.
- [ ] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation and/or `CHANGELOG.md` accordingly.
