### PR TITLE
fix(pytauri)!: make `BuilderArgs.invoke_handler` as required parameter for #110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING
+
+- [#133](https://github.com/pytauri/pytauri/pull/113) - fix(pytauri)!: make `BuilderArgs.invoke_handler` as required parameter for #110.
+
+    If you do not specify `invoke_handler`,
+    `pytauri` will not register the `tauri-plugin-pytauri` plugin,
+    which means you cannot use `pyInvoke` in the frontend to call `Commands`
+    (you will receive an error like ["plugin pytauri not found"]).
+    If this is indeed the behavior you expect, explicitly pass `None`.
+
+    ["plugin pytauri not found"]: https://github.com/pytauri/pytauri/issues/110
+
 ### Added
 
 - [#124](https://github.com/pytauri/pytauri/pull/124) - chore: bump `tauri` dependencies:

--- a/crates/pytauri/CHANGELOG.md
+++ b/crates/pytauri/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### BREAKING
+
+- [#133](https://github.com/pytauri/pytauri/pull/113) - fix(pytauri)!: make `BuilderArgs.invoke_handler` as required parameter for #110.
+
 ## [0.4.0]
 
 bump workspace version

--- a/crates/pytauri/src/lib.rs
+++ b/crates/pytauri/src/lib.rs
@@ -47,7 +47,7 @@ pub struct BuilderArgs {
 #[pymethods]
 impl BuilderArgs {
     #[new]
-    #[pyo3(signature = (context, *, invoke_handler = None, setup = None))]
+    #[pyo3(signature = (context, *, invoke_handler, setup = None))]
     fn new(
         context: Py<ext_mod::Context>,
         invoke_handler: Option<PyObject>,

--- a/docs/usage/tutorial/using-pytauri.md
+++ b/docs/usage/tutorial/using-pytauri.md
@@ -83,6 +83,7 @@ def main() -> int:
     app = builder_factory().build(
         BuilderArgs(
             context=context_factory(),
+            invoke_handler=None,  # TODO
         )
     )
     exit_code = app.run_return()

--- a/examples/nicegui-app/python/nicegui_app/__init__.py
+++ b/examples/nicegui-app/python/nicegui_app/__init__.py
@@ -103,6 +103,7 @@ def main() -> int:
         tauri_app = builder_factory().build(
             BuilderArgs(
                 context_factory(),
+                invoke_handler=None,
                 setup=app_setup_hook(front_server),
             )
         )

--- a/python/pytauri/CHANGELOG.md
+++ b/python/pytauri/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### BREAKING
+
+- [#133](https://github.com/pytauri/pytauri/pull/113) - fix(pytauri)!: make `BuilderArgs.invoke_handler` as required parameter for #110.
+
 ### Added
 
 - [#124](https://github.com/pytauri/pytauri/pull/124) - feat: introduce `App::run_return`:

--- a/python/pytauri/src/pytauri/ffi/lib.py
+++ b/python/pytauri/src/pytauri/ffi/lib.py
@@ -201,15 +201,24 @@ if TYPE_CHECKING:
             /,
             context: "Context",
             *,
-            invoke_handler: Optional[_InvokeHandlerProto] = None,
+            invoke_handler: Optional[_InvokeHandlerProto],
             setup: Optional[Callable[[AppHandle], object]] = None,
         ) -> Self:
             """[tauri::Builder](https://docs.rs/tauri/latest/tauri/struct.Builder.html)
 
             !!! warning
-                The implementer of `invoke_handler` must never raise an exception,
-                otherwise it is considered undefined behavior.
+                The implementer of [invoke_handler][pytauri.ffi.lib.BuilderArgs.__new__(invoke_handler)] must never raise an exception,
+                otherwise it is considered logical undefined behavior.
                 Additionally, `invoke_handler` must not block.
+
+            !!! warning
+                If you do not specify [invoke_handler][pytauri.ffi.lib.BuilderArgs.__new__(invoke_handler)],
+                `pytauri` will not register the `tauri-plugin-pytauri` plugin,
+                which means you cannot use `pyInvoke` in the frontend to call `Commands`
+                (you will receive an error like ["plugin pytauri not found"]).
+                If this is indeed the behavior you expect, explicitly pass [None][].
+
+                ["plugin pytauri not found"]: https://github.com/pytauri/pytauri/issues/110
 
             Args:
                 context: use [context_factory][pytauri.context_factory] to get it.


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

If you do not specify `invoke_handler`,
`pytauri` will not register the `tauri-plugin-pytauri` plugin,
which means you cannot use `pyInvoke` in the frontend to call `Commands`
(you will receive an error like ["plugin pytauri not found"]).
If this is indeed the behavior you expect, explicitly pass `None`.

["plugin pytauri not found"]: https://github.com/pytauri/pytauri/issues/110

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
