### PR TITLE
feat(plugin): implement `tauri-plugin-dialog` bindings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "pytauri-core/__private",
     "pytauri/standalone",
     "pytauri/plugin-notification",
+    "pytauri/plugin-dialog",
     "pyo3-utils/unstable",
   ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Highlights
 
+#### `tauri-plugin-dialog` bingings
+
+> - [#163](https://github.com/pytauri/pytauri/pull/163) - feat(plugin): implement `tauri-plugin-dialog` bindings.
+
+[`tauri-plugin-dialog`](https://tauri.app/plugin/dialog/) has now been integrated into `pytauri` as the `plugin-dialog` gated feature.
+
+??? tip "Usage"
+
+    ![dialog](https://github.com/user-attachments/assets/85cbf9f1-4203-4336-959a-499b3691bcd9)
+
+    ```py
+    from pytauri_plugins.dialog import DialogExt, MessageDialogButtons, MessageDialogKind
+
+    @commands.command()
+    async def greet(
+        app_handle: AppHandle, webview_window: WebviewWindow
+    ) -> bytes:
+        file_dialog_builder = DialogExt.file(app_handle)
+        file_dialog_builder.pick_files(
+            lambda files: print(f"Files selected: {files}"),
+            add_filter=("markdown", ["md"]),
+            set_parent=webview_window,
+            set_title="Select a Markdown file",
+        )
+
+        message_dialog_builder = DialogExt.message(app_handle, "Hello!")
+        message_dialog_builder.show(
+            lambda is_ok: print(f"Dialog closed with: {is_ok}"),
+            parent=webview_window,
+            buttons=MessageDialogButtons.OkCancelCustom("ok", "cancel"),
+            kind=MessageDialogKind.Info,
+        )
+
+        return b"null"
+    ```
+
 #### Integrate plugins as features
 
 > - [#160](https://github.com/pytauri/pytauri/pull/160) - feat(pytauri)!: integrate `plugin-notification` as a gated-feature of `pytauri`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-pytauri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "pyo3",
  "pyo3-utils",
  "tauri",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin = { version = "2.2" }
 
 tauri-plugin-notification = { version = "2.2" }
 tauri-plugin-opener = { version = "2.2" }
+tauri-plugin-dialog = { version = "2.2" }
 
 serde = { version = "1" }
 serde_json = { version = "1" }

--- a/crates/pytauri-core/CHANGELOG.md
+++ b/crates/pytauri-core/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### BREAKING
 
+- [#163](https://github.com/pytauri/pytauri/pull/163) - refactor: `ext_mod::Url` -> `ext_mod::Url<'a'>` and removed the implementations of `Deref` and `DerefMut`.
 - [#157](https://github.com/pytauri/pytauri/pull/157) - feat!: `Position.Physical(x, y)` -> `Position.Physical((x, y))`. See home `/CHANGELOG` for more details.
 
 ### Added
 
+- [#163](https://github.com/pytauri/pytauri/pull/163) - feat(plugin): implement `tauri-plugin-dialog` bindings.
 - [#160](https://github.com/pytauri/pytauri/pull/160) - feat!: integrate `plugin-notification` as a gated-feature of `pytauri`.
 
     Added: `pytauri_plugins::notification::NotificationBuilderArgs`.

--- a/crates/pytauri-core/Cargo.toml
+++ b/crates/pytauri-core/Cargo.toml
@@ -24,6 +24,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 tauri = { workspace = true, features = ["wry", "tray-icon"] }
 # tauri plugins
 tauri-plugin-notification = { workspace = true, optional = true }
+tauri-plugin-dialog = { workspace = true, optional = true }
 
 pyo3 = { workspace = true }
 
@@ -37,3 +38,4 @@ __test = ["tauri/test"]
 __no_test = []          # for allowing use `--all-features` without running tests
 
 plugin-notification = ["dep:tauri-plugin-notification"]
+plugin-dialog = ["dep:tauri-plugin-dialog"]

--- a/crates/pytauri-core/src/ext_mod_impl/ipc.rs
+++ b/crates/pytauri-core/src/ext_mod_impl/ipc.rs
@@ -270,7 +270,7 @@ impl JavaScriptChannelId {
 impl JavaScriptChannelId {
     #[staticmethod]
     fn from_str(py: Python<'_>, value: &str) -> PyResult<Self> {
-        // it's short enough, so we don't release the GIL
+        // PERF: it's short enough, so we don't release the GIL
         let result = ipc::JavaScriptChannelId::from_str(value);
         match result {
             Ok(js_channel_id) => Ok(Self::new(js_channel_id)),

--- a/crates/pytauri-core/src/ext_mod_impl/webview.rs
+++ b/crates/pytauri-core/src/ext_mod_impl/webview.rs
@@ -347,7 +347,7 @@ impl WebviewWindow {
         Ok(url.into())
     }
 
-    fn navigate(&self, py: Python<'_>, url: Url) -> PyResult<()> {
+    fn navigate(&self, py: Python<'_>, url: Url<'_>) -> PyResult<()> {
         py.allow_threads(|| delegate_inner!(self, navigate, url.into()))
     }
 

--- a/crates/pytauri-core/src/plugins/dialog/mod.rs
+++ b/crates/pytauri-core/src/plugins/dialog/mod.rs
@@ -2,10 +2,11 @@ use std::{
     error::Error,
     fmt::{Debug, Display, Formatter},
     ops::Deref,
+    path::PathBuf,
 };
 
 use pyo3::{
-    exceptions::PyRuntimeError,
+    exceptions::{PyNotImplementedError, PyRuntimeError},
     prelude::*,
     pybacked::PyBackedStr,
     types::{PyDict, PyString},
@@ -242,6 +243,373 @@ impl MessageDialogBuilder {
     }
 }
 
+// TODO: unify this type with [tauri_plugin_fs::FilePath]
+/// See also: [tauri_plugin_dialog::FilePath]
+pub struct FilePath(plugin::FilePath);
+
+impl From<plugin::FilePath> for FilePath {
+    fn from(value: plugin::FilePath) -> Self {
+        Self(value)
+    }
+}
+
+impl From<FilePath> for plugin::FilePath {
+    fn from(value: FilePath) -> Self {
+        value.0
+    }
+}
+
+/// `pathlib.Path`
+impl<'py> IntoPyObject<'py> for &FilePath {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let ret = match &self.0 {
+            plugin::FilePath::Url(_) => {
+                // TODO: support Android/iOS:
+                //
+                // let pyobj: Bound<'_, PyString> = Url::from(url).into_pyobject(py)?;
+                // pyobj.into_any() // str
+                return Err(PyNotImplementedError::new_err(
+                    "[FilePath::Url] type is only used on Android/iOS, report this to the pytauri developers"
+                ));
+            }
+            plugin::FilePath::Path(path) => {
+                let path: &PathBuf = path;
+                let pyobj: Bound<'_, PyAny> = path.into_pyobject(py)?; // pathlib.Path
+                pyobj
+            }
+        };
+        Ok(ret)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for FilePath {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (&self).into_pyobject(py)
+    }
+}
+
+/// See also: [tauri_plugin_dialog::FileDialogBuilder]
+#[non_exhaustive]
+pub struct FileDialogBuilderArgs {
+    // TODO, PERF: avoid `Vec`, use `PyIterable` or `smallvec` instead.
+    add_filter: NotRequired<(String, Vec<PyBackedStr>)>,
+    // PERF: avoid `PathBuf`, prefer `&Path` instead.
+    set_directory: NotRequired<PathBuf>,
+    set_file_name: NotRequired<String>,
+    set_parent: NotRequired<HasWindowHandleAndHasDisplayHandle>,
+    set_title: NotRequired<String>,
+    set_can_create_directories: NotRequired<bool>,
+}
+
+derive_from_py_dict!(FileDialogBuilderArgs {
+    #[default]
+    add_filter,
+    #[default]
+    set_directory,
+    #[default]
+    set_file_name,
+    #[default]
+    set_parent,
+    #[default]
+    set_title,
+    #[default]
+    set_can_create_directories,
+});
+
+impl FileDialogBuilderArgs {
+    fn from_kwargs(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Option<Self>> {
+        kwargs.map(FileDialogBuilderArgs::from_py_dict).transpose()
+    }
+
+    fn apply_to_builder(
+        self,
+        mut builder: plugin::FileDialogBuilder<Runtime>,
+    ) -> plugin::FileDialogBuilder<Runtime> {
+        let Self {
+            add_filter,
+            set_directory,
+            set_file_name,
+            set_parent,
+            set_title,
+            set_can_create_directories,
+        } = self;
+
+        if let Some((name, extensions)) = add_filter.0 {
+            // TODO, PERF: avoid alloc `Vec` (because `collect`) here
+            let extensions = extensions.iter().map(|s| s.deref()).collect::<Vec<_>>();
+            builder = builder.add_filter(name, &extensions);
+        }
+        if let Some(directory) = set_directory.0 {
+            builder = builder.set_directory(directory);
+        }
+        if let Some(file_name) = set_file_name.0 {
+            builder = builder.set_file_name(file_name);
+        }
+        if let Some(parent) = set_parent.0 {
+            builder = builder.set_parent(&*parent.get().0.inner_ref());
+        }
+        if let Some(title) = set_title.0 {
+            builder = builder.set_title(title);
+        }
+        if let Some(can_create_directories) = set_can_create_directories.0 {
+            builder = builder.set_can_create_directories(can_create_directories);
+        }
+
+        builder
+    }
+}
+
+/// See also: [tauri_plugin_dialog::FileDialogBuilder]
+#[pyclass(frozen)]
+#[non_exhaustive]
+// [tauri_plugin_dialog::FileDialogBuilder] is `!Sync`,
+// so we wrap [tauri::AppHandle] instead.
+pub struct FileDialogBuilder {
+    handle: tauri::AppHandle<Runtime>,
+}
+
+impl FileDialogBuilder {
+    fn to_tauri(&self) -> plugin::FileDialogBuilder<Runtime> {
+        let Self { handle } = self;
+        handle.dialog().file()
+    }
+}
+
+#[pymethods]
+impl FileDialogBuilder {
+    #[pyo3(signature = (handler, /, **kwargs))]
+    fn pick_file(&self, handler: PyObject, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        // PERF: it's short enough, so we don't release the GIL
+        builder.pick_file(move |file_path| {
+            Python::with_gil(|py| {
+                let file_path = file_path.map(FilePath::from);
+
+                let handler = handler.bind(py);
+                let result = handler.call1((file_path,));
+                result.unwrap_unraisable_py_result(py, Some(handler), || {
+                    "Python exception occurred in `FileDialogBuilder::pick_file` handler"
+                });
+            })
+        });
+
+        Ok(())
+    }
+
+    #[pyo3(signature = (**kwargs))]
+    fn blocking_pick_file(
+        &self,
+        py: Python<'_>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<FilePath>> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        let ret = py.allow_threads(|| builder.blocking_pick_file().map(Into::into));
+        Ok(ret)
+    }
+
+    #[pyo3(signature = (handler, / ,**kwargs))]
+    fn pick_files(&self, handler: PyObject, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        // PERF: it's short enough, so we don't release the GIL
+        builder.pick_files(move |file_paths| {
+            Python::with_gil(|py| {
+                let file_paths = file_paths
+                    // TODO, PERF: avoid `Vec`, use `PyList` instead
+                    .map(|files| files.into_iter().map(FilePath::from).collect::<Vec<_>>());
+
+                let handler = handler.bind(py);
+                let result = handler.call1((file_paths,));
+                result.unwrap_unraisable_py_result(py, Some(handler), || {
+                    "Python exception occurred in `FileDialogBuilder::pick_files` handler"
+                });
+            })
+        });
+
+        Ok(())
+    }
+
+    #[pyo3(signature = (**kwargs))]
+    fn blocking_pick_files(
+        &self,
+        py: Python<'_>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<Vec<FilePath>>> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        let ret = py.allow_threads(|| {
+            builder
+                .blocking_pick_files()
+                // TODO, PERF: avoid `Vec`, use `PyList` instead
+                .map(|files| files.into_iter().map(Into::into).collect::<Vec<_>>())
+        });
+        Ok(ret)
+    }
+
+    #[pyo3(signature = (handler, / ,**kwargs))]
+    fn pick_folder(&self, handler: PyObject, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        // PERF: it's short enough, so we don't release the GIL
+        builder.pick_folder(move |file_path| {
+            Python::with_gil(|py| {
+                let file_path = file_path.map(FilePath::from);
+
+                let handler = handler.bind(py);
+                let result = handler.call1((file_path,));
+                result.unwrap_unraisable_py_result(py, Some(handler), || {
+                    "Python exception occurred in `FileDialogBuilder::pick_folder` handler"
+                });
+            })
+        });
+
+        Ok(())
+    }
+
+    #[pyo3(signature = (**kwargs))]
+    fn blocking_pick_folder(
+        &self,
+        py: Python<'_>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<FilePath>> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        let ret = py.allow_threads(|| builder.blocking_pick_folder().map(Into::into));
+        Ok(ret)
+    }
+
+    #[pyo3(signature = (handler, / ,**kwargs))]
+    fn pick_folders(&self, handler: PyObject, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        // PERF: it's short enough, so we don't release the GIL
+        builder.pick_folders(move |file_paths| {
+            Python::with_gil(|py| {
+                let file_paths = file_paths
+                    // TODO, PERF: avoid `Vec`, use `PyList` instead
+                    .map(|files| files.into_iter().map(FilePath::from).collect::<Vec<_>>());
+
+                let handler = handler.bind(py);
+                let result = handler.call1((file_paths,));
+                result.unwrap_unraisable_py_result(py, Some(handler), || {
+                    "Python exception occurred in `FileDialogBuilder::pick_folders` handler"
+                });
+            })
+        });
+
+        Ok(())
+    }
+
+    #[pyo3(signature = (**kwargs))]
+    fn blocking_pick_folders(
+        &self,
+        py: Python<'_>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<Vec<FilePath>>> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        let ret = py.allow_threads(|| {
+            builder
+                .blocking_pick_folders()
+                // TODO, PERF: avoid `Vec`, use `PyList` instead
+                .map(|files| files.into_iter().map(Into::into).collect::<Vec<_>>())
+        });
+        Ok(ret)
+    }
+
+    #[pyo3(signature = (handler, / ,**kwargs))]
+    fn save_file(&self, handler: PyObject, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        // PERF: it's short enough, so we don't release the GIL
+        builder.save_file(move |file_path| {
+            Python::with_gil(|py| {
+                let file_path = file_path.map(FilePath::from);
+
+                let handler = handler.bind(py);
+                let result = handler.call1((file_path,));
+                result.unwrap_unraisable_py_result(py, Some(handler), || {
+                    "Python exception occurred in `FileDialogBuilder::save_file` handler"
+                });
+            })
+        });
+
+        Ok(())
+    }
+
+    #[pyo3(signature = (**kwargs))]
+    fn blocking_save_file(
+        &self,
+        py: Python<'_>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<FilePath>> {
+        let args = FileDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(builder);
+        }
+
+        let ret = py.allow_threads(|| builder.blocking_save_file().map(Into::into));
+        Ok(ret)
+    }
+}
+
 /// See also: [tauri_plugin_dialog::DialogExt]
 #[pyclass(frozen)]
 #[non_exhaustive]
@@ -264,13 +632,24 @@ impl DialogExt {
             MessageDialogBuilder { handle, message }
         })
     }
+
+    #[staticmethod]
+    fn file(slf: ImplDialogExt, py: Python<'_>) -> PyResult<FileDialogBuilder> {
+        manager_method_impl!(py, &slf, |_py, manager| {
+            // PERF: it's short enough, so we don't release the GIL
+            let handle = manager.app_handle().clone();
+            FileDialogBuilder { handle }
+        })
+    }
 }
 
 /// See also: [tauri_plugin_dialog]
 #[pymodule(submodule, gil_used = false)]
 pub mod dialog {
     #[pymodule_export]
-    pub use super::{DialogExt, MessageDialogBuilder, MessageDialogButtons, MessageDialogKind};
+    pub use super::{
+        DialogExt, FileDialogBuilder, MessageDialogBuilder, MessageDialogButtons, MessageDialogKind,
+    };
 
-    pub use super::{ImplDialogExt, MessageDialogBuilderArgs};
+    pub use super::{FileDialogBuilderArgs, FilePath, ImplDialogExt, MessageDialogBuilderArgs};
 }

--- a/crates/pytauri-core/src/plugins/dialog/mod.rs
+++ b/crates/pytauri-core/src/plugins/dialog/mod.rs
@@ -1,0 +1,278 @@
+use std::{
+    error::Error,
+    fmt::{Debug, Display, Formatter},
+    ops::Deref,
+};
+
+use pyo3::{
+    exceptions::PyRuntimeError,
+    prelude::*,
+    pybacked::PyBackedStr,
+    types::{PyDict, PyString},
+};
+use pyo3_utils::from_py_dict::{derive_from_py_dict, FromPyDict as _, NotRequired};
+use tauri::Manager as _;
+use tauri_plugin_dialog::{self as plugin, DialogExt as _};
+
+use crate::{
+    ext_mod::{manager_method_impl, webview::WebviewWindow, ImplManager},
+    tauri_runtime::Runtime,
+    utils::{PyResultExt as _, TauriError},
+};
+
+#[derive(Debug)]
+struct PluginError(plugin::Error);
+
+impl Display for PluginError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Error for PluginError {}
+
+impl From<PluginError> for PyErr {
+    fn from(value: PluginError) -> Self {
+        match value.0 {
+            plugin::Error::Io(e) => e.into(),
+            plugin::Error::Tauri(e) => TauriError::from(e).into(),
+            // TODO: unify this error with `tauri_plugin_fs::Error`
+            plugin::Error::Fs(e) => PyRuntimeError::new_err(e.to_string()),
+            non_exhaustive => PyRuntimeError::new_err(format!(
+                "Unimplemented plugin error, please report this to the pytauri developers: {non_exhaustive}"
+            )),
+        }
+    }
+}
+
+impl From<plugin::Error> for PluginError {
+    fn from(value: plugin::Error) -> Self {
+        Self(value)
+    }
+}
+
+// TODO: support `tauri::window::Window` also, something like:
+//
+// ```rust
+// // TODO: unify/stable this in `pytauri_core::ext_mod`
+// #[non_exhaustive]
+// #[derive(FromPyObject)]
+// enum HasWindowHandleAndHasDisplayHandle {
+//     WebviewWindow(Py<WebviewWindow>),
+//     Window(Py<Window>),
+// }
+// ```
+type HasWindowHandleAndHasDisplayHandle = Py<WebviewWindow>;
+
+/// See also: [tauri_plugin_dialog::MessageDialogButtons]
+#[pyclass(frozen)]
+#[non_exhaustive]
+pub enum MessageDialogButtons {
+    Ok(),
+    OkCancel(),
+    YesNo(),
+    // TODO, PERF: or we can use [pyo3::pybacked::PyBackedStr],
+    // so that we don't need to require GIL for `fn to_tauri`.
+    OkCustom(Py<PyString>),
+    OkCancelCustom(Py<PyString>, Py<PyString>),
+}
+
+impl MessageDialogButtons {
+    fn to_tauri(&self, py: Python<'_>) -> PyResult<plugin::MessageDialogButtons> {
+        let ret = match self {
+            MessageDialogButtons::Ok() => plugin::MessageDialogButtons::Ok,
+            MessageDialogButtons::OkCancel() => plugin::MessageDialogButtons::OkCancel,
+            MessageDialogButtons::YesNo() => plugin::MessageDialogButtons::YesNo,
+            MessageDialogButtons::OkCustom(text) => {
+                // TODO, PERF: once we drop py39 support, we can use [PyStringMethods::to_str] directly.
+                plugin::MessageDialogButtons::OkCustom(text.to_cow(py)?.into_owned())
+            }
+            MessageDialogButtons::OkCancelCustom(ok_text, cancel_text) => {
+                // TODO, PERF: once we drop py39 support, we can use [PyStringMethods::to_str] directly.
+                plugin::MessageDialogButtons::OkCancelCustom(
+                    ok_text.to_cow(py)?.into_owned(),
+                    cancel_text.to_cow(py)?.into_owned(),
+                )
+            }
+        };
+        Ok(ret)
+    }
+}
+
+macro_rules! message_dialog_kind_impl {
+    ($ident:ident => : $($variant:ident),*) => {
+        /// See also: [tauri_plugin_dialog::MessageDialogKind]
+        #[pyclass(frozen, eq, eq_int)]
+        #[derive(PartialEq, Clone, Copy)]
+        pub enum $ident {
+            $($variant,)*
+        }
+
+        impl From<$ident> for tauri_plugin_dialog::MessageDialogKind {
+            fn from(val: $ident) -> Self {
+                match val {
+                    $($ident::$variant => tauri_plugin_dialog::MessageDialogKind::$variant,)*
+                }
+            }
+        }
+    };
+}
+
+message_dialog_kind_impl!(
+    MessageDialogKind => :
+    Info,
+    Warning,
+    Error
+);
+
+/// See also: [tauri_plugin_dialog::MessageDialogBuilder]
+#[non_exhaustive]
+pub struct MessageDialogBuilderArgs {
+    title: NotRequired<String>,
+    parent: NotRequired<HasWindowHandleAndHasDisplayHandle>,
+    buttons: NotRequired<Py<MessageDialogButtons>>,
+    kind: NotRequired<Py<MessageDialogKind>>,
+}
+
+derive_from_py_dict!(MessageDialogBuilderArgs {
+    #[default]
+    title,
+    #[default]
+    parent,
+    #[default]
+    buttons,
+    #[default]
+    kind,
+});
+
+impl MessageDialogBuilderArgs {
+    fn from_kwargs(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Option<Self>> {
+        kwargs
+            .map(MessageDialogBuilderArgs::from_py_dict)
+            .transpose()
+    }
+
+    fn apply_to_builder(
+        self,
+        py: Python<'_>,
+        mut builder: plugin::MessageDialogBuilder<Runtime>,
+    ) -> PyResult<plugin::MessageDialogBuilder<Runtime>> {
+        let Self {
+            title,
+            parent,
+            buttons,
+            kind,
+        } = self;
+
+        if let Some(title) = title.0 {
+            builder = builder.title(title);
+        }
+        if let Some(parent) = parent.0 {
+            builder = builder.parent(&*parent.get().0.inner_ref());
+        }
+        if let Some(buttons) = buttons.0 {
+            builder = builder.buttons(buttons.get().to_tauri(py)?);
+        }
+        if let Some(kind) = kind.0 {
+            builder = builder.kind((*kind.get()).into());
+        }
+
+        Ok(builder)
+    }
+}
+
+/// See also: [tauri_plugin_dialog::MessageDialogBuilder]
+#[pyclass(frozen)]
+#[non_exhaustive]
+// [tauri_plugin_dialog::MessageDialogBuilder] is `!Sync`,
+// so we wrap [tauri::AppHandle] instead.
+pub struct MessageDialogBuilder {
+    handle: tauri::AppHandle<Runtime>,
+    message: PyBackedStr,
+}
+
+impl MessageDialogBuilder {
+    fn to_tauri(&self) -> plugin::MessageDialogBuilder<Runtime> {
+        let Self { handle, message } = self;
+        handle.dialog().message(message.deref())
+    }
+}
+
+#[pymethods]
+impl MessageDialogBuilder {
+    #[pyo3(signature = (**kwargs))]
+    fn blocking_show(&self, py: Python<'_>, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<bool> {
+        let args = MessageDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(py, builder)?;
+        }
+
+        let ret = py.allow_threads(|| builder.blocking_show());
+        Ok(ret)
+    }
+
+    #[pyo3(signature = (handler, /, **kwargs))]
+    fn show(
+        &self,
+        py: Python<'_>,
+        handler: PyObject,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        let args = MessageDialogBuilderArgs::from_kwargs(kwargs)?;
+
+        let mut builder = self.to_tauri();
+        if let Some(args) = args {
+            builder = args.apply_to_builder(py, builder)?;
+        }
+
+        // TODO (perf): Do we really need `py.allow_threads` here?
+        // Maybe it's short enough?
+        py.allow_threads(|| {
+            builder.show(move |is_ok| {
+                Python::with_gil(|py| {
+                    let handler = handler.bind(py);
+                    let result = handler.call1((is_ok,));
+                    result.unwrap_unraisable_py_result(py, Some(handler), || {
+                        "Python exception occurred in `MessageDialogBuilder::show` handler"
+                    });
+                })
+            })
+        });
+        Ok(())
+    }
+}
+
+/// See also: [tauri_plugin_dialog::DialogExt]
+#[pyclass(frozen)]
+#[non_exhaustive]
+pub struct DialogExt;
+
+/// The Implementers of [tauri_plugin_dialog::DialogExt].
+pub type ImplDialogExt = ImplManager;
+
+#[pymethods]
+impl DialogExt {
+    #[staticmethod]
+    fn message(
+        slf: ImplDialogExt,
+        py: Python<'_>,
+        message: PyBackedStr,
+    ) -> PyResult<MessageDialogBuilder> {
+        manager_method_impl!(py, &slf, |_py, manager| {
+            // PERF: it's short enough, so we don't release the GIL
+            let handle = manager.app_handle().clone();
+            MessageDialogBuilder { handle, message }
+        })
+    }
+}
+
+/// See also: [tauri_plugin_dialog]
+#[pymodule(submodule, gil_used = false)]
+pub mod dialog {
+    #[pymodule_export]
+    pub use super::{DialogExt, MessageDialogBuilder, MessageDialogButtons, MessageDialogKind};
+
+    pub use super::{ImplDialogExt, MessageDialogBuilderArgs};
+}

--- a/crates/pytauri-core/src/plugins/mod.rs
+++ b/crates/pytauri-core/src/plugins/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "plugin-dialog")]
+mod dialog;
 #[cfg(feature = "plugin-notification")]
 mod notification;
 
@@ -15,7 +17,15 @@ pub mod pytauri_plugins {
     #[pymodule_export]
     pub const PLUGIN_NOTIFICATION: bool = cfg!(feature = "plugin-notification");
 
+    /// Whether the `plugin-dialog` feature is enabled.
+    #[pymodule_export]
+    pub const PLUGIN_DIALOG: bool = cfg!(feature = "plugin-dialog");
+
     #[cfg(feature = "plugin-notification")]
     #[pymodule_export]
     pub use notification::notification;
+
+    #[cfg(feature = "plugin-dialog")]
+    #[pymodule_export]
+    pub use dialog::dialog;
 }

--- a/crates/pytauri/Cargo.toml
+++ b/crates/pytauri/Cargo.toml
@@ -24,6 +24,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 standalone = ["dep:libc", "dep:dunce"]
 
 plugin-notification = ["pytauri-core/plugin-notification"]
+plugin-dialog = ["pytauri-core/plugin-dialog"]
 
 
 [dependencies]

--- a/docs/usage/tutorial/using-plugins.md
+++ b/docs/usage/tutorial/using-plugins.md
@@ -11,6 +11,13 @@ In addition, PyTauri has already integrated some official Tauri plugins. Below, 
 
 [tauri-plugin-notification]: https://github.com/tauri-apps/tauri-plugin-notification
 
+## All plugins we support
+
+| Plugin | JS Docs | Rust Docs | Python Docs |
+|--------|---------|-----------|-------------|
+| plugin-notification | [JS docs](https://tauri.app/reference/javascript/notification/) | [Rust docs](https://docs.rs/tauri-plugin-notification/latest/tauri_plugin_notification/) | [Python docs][pytauri_plugins.notification] |
+| plugin-dialog | [JS docs](https://tauri.app/reference/javascript/dialog/) | [Rust docs](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/) | [Python docs][pytauri_plugins.dialog] |
+
 ## Using the plugin
 
 ### install tauri plugin

--- a/examples/tauri-app/src-tauri/Cargo.toml
+++ b/examples/tauri-app/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 pyo3 = { workspace = true }
-pytauri = { workspace = true, features = ["plugin-notification"] }
+pytauri = { workspace = true, features = [
+    "plugin-notification",
+    "plugin-dialog",
+] }
 tauri-plugin-pytauri = { workspace = true }
 tauri-plugin-notification = { workspace = true }
+tauri-plugin-dialog = { workspace = true }

--- a/examples/tauri-app/src-tauri/capabilities/default.json
+++ b/examples/tauri-app/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "pytauri:default",
-    "notification:default"
+    "notification:default",
+    "dialog:default"
   ]
 }

--- a/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
+++ b/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
@@ -22,6 +22,7 @@ from pytauri import (
 )
 from pytauri.ipc import Channel, JavaScriptChannelId
 from pytauri.webview import WebviewWindow
+from pytauri_plugins.dialog import DialogExt, MessageDialogButtons, MessageDialogKind
 from pytauri_plugins.notification import NotificationExt
 
 from tauri_app.private import private_algorithm
@@ -90,7 +91,14 @@ async def greet(
     body: Person, app_handle: AppHandle, webview_window: WebviewWindow
 ) -> Greeting:
     notification_builder = NotificationExt.builder(app_handle)
-    notification_builder.show(title="Greeting", body=f"Hello, {body.name}!")
+
+    message_dialog_builder = DialogExt.message(app_handle, f"Hello {body.name}!")
+    message_dialog_builder.show(
+        lambda is_ok: notification_builder.show(body=f"Dialog closed with: {is_ok}"),
+        parent=webview_window,
+        buttons=MessageDialogButtons.OkCancelCustom("ok", "cancel"),
+        kind=MessageDialogKind.Info,
+    )
 
     webview_window.set_title(f"Hello {body.name}!")
 

--- a/examples/tauri-app/src-tauri/src/lib.rs
+++ b/examples/tauri-app/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub mod ext_mod {
                 let builder = tauri::Builder::default()
                     .plugin(tauri_plugin_opener::init())
                     .plugin(tauri_plugin_notification::init())
+                    .plugin(tauri_plugin_dialog::init())
                     .invoke_handler(tauri::generate_handler![greet]);
                 Ok(builder)
             },

--- a/python/pytauri/CHANGELOG.md
+++ b/python/pytauri/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- [#163](https://github.com/pytauri/pytauri/pull/163) - feat(plugin): implement `tauri-plugin-dialog` bindings.
 - [#160](https://github.com/pytauri/pytauri/pull/160) - feat!: integrate `plugin-notification` as a gated-feature of `pytauri`.
 
     Added: `pytauri_plugins::notification::NotificationBuilderArgs`.

--- a/python/pytauri/src/pytauri/ffi/_typing.py
+++ b/python/pytauri/src/pytauri/ffi/_typing.py
@@ -1,0 +1,15 @@
+from os import PathLike
+from pathlib import Path
+from typing import Union
+
+from typing_extensions import TypeAlias
+
+__all__ = ["Pyo3Path", "StrictPyo3Path"]
+
+# NOTE: only `PathLike[str]`, not `PathLike[bytes]`,
+# ref: <https://github.com/PyO3/pyo3/blob/daa3ee7897011c95775ce7617b4c1c7cadd8db49/src/conversions/std/path.rs#L17>
+Pyo3Path: TypeAlias = Union[str, PathLike[str], Path]
+"""The input type of `std::path::PathBuf`"""
+
+StrictPyo3Path: TypeAlias = Path
+"""The return type of `std::path::PathBuf`"""

--- a/python/pytauri/src/pytauri/ffi/tray.py
+++ b/python/pytauri/src/pytauri/ffi/tray.py
@@ -3,8 +3,6 @@
 """[tauri::tray](https://docs.rs/tauri/latest/tauri/tray/index.html)"""
 
 from enum import Enum, auto
-from os import PathLike
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -16,6 +14,7 @@ from typing import (
 from typing_extensions import Self, TypeAliasType
 
 from pytauri.ffi._ext_mod import pytauri_mod
+from pytauri.ffi._typing import Pyo3Path
 
 __all__ = [
     "MouseButton",
@@ -26,7 +25,6 @@ __all__ = [
     "TrayIconId",
 ]
 
-_ToPyo3Path = Union[str, PathLike[str], Path]
 
 _tray_mod = pytauri_mod.tray
 
@@ -73,7 +71,7 @@ if TYPE_CHECKING:
         def set_tooltip(self, tooltip: Optional[str], /) -> None: ...
         def set_title(self, title: Optional[str], /) -> None: ...
         def set_visible(self, visible: bool, /) -> None: ...
-        def set_temp_dir_path(self, path: Optional[_ToPyo3Path], /) -> None: ...
+        def set_temp_dir_path(self, path: Optional[Pyo3Path], /) -> None: ...
         def set_icon_as_template(self, is_template: bool, /) -> None: ...
         def set_show_menu_on_left_click(self, enable: bool, /) -> None: ...
         def rect(self, /) -> Optional[Rect]: ...

--- a/python/pytauri/src/pytauri_plugins/__init__.py
+++ b/python/pytauri/src/pytauri_plugins/__init__.py
@@ -12,6 +12,7 @@ from typing import Final
 from pytauri import EXT_MOD
 
 __all__ = [
+    "PLUGIN_DIALOG",
     "PLUGIN_NOTIFICATION",
 ]
 
@@ -19,3 +20,5 @@ _pytauri_plugins_mod: ModuleType = EXT_MOD.pytauri_plugins
 
 PLUGIN_NOTIFICATION: Final[bool] = _pytauri_plugins_mod.PLUGIN_NOTIFICATION
 """Whether the `plugin-notification` feature is enabled."""
+PLUGIN_DIALOG: Final[bool] = _pytauri_plugins_mod.PLUGIN_DIALOG
+"""Whether the `plugin-dialog` feature is enabled."""

--- a/python/pytauri/src/pytauri_plugins/dialog/__init__.py
+++ b/python/pytauri/src/pytauri_plugins/dialog/__init__.py
@@ -1,0 +1,21 @@
+"""[tauri_plugin_dialog::self](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/index.html)"""
+
+from pytauri_plugins.dialog.ffi import (
+    DialogExt,
+    ImplDialogExt,
+    MessageDialogBuilder,
+    MessageDialogBuilderArgs,
+    MessageDialogButtons,
+    MessageDialogButtonsType,
+    MessageDialogKind,
+)
+
+__all__ = [
+    "DialogExt",
+    "ImplDialogExt",
+    "MessageDialogBuilder",
+    "MessageDialogBuilderArgs",
+    "MessageDialogButtons",
+    "MessageDialogButtonsType",
+    "MessageDialogKind",
+]

--- a/python/pytauri/src/pytauri_plugins/dialog/__init__.py
+++ b/python/pytauri/src/pytauri_plugins/dialog/__init__.py
@@ -2,6 +2,9 @@
 
 from pytauri_plugins.dialog.ffi import (
     DialogExt,
+    FileDialogBuilder,
+    FileDialogBuilderArgs,
+    FilePath,
     ImplDialogExt,
     MessageDialogBuilder,
     MessageDialogBuilderArgs,
@@ -12,6 +15,9 @@ from pytauri_plugins.dialog.ffi import (
 
 __all__ = [
     "DialogExt",
+    "FileDialogBuilder",
+    "FileDialogBuilderArgs",
+    "FilePath",
     "ImplDialogExt",
     "MessageDialogBuilder",
     "MessageDialogBuilderArgs",

--- a/python/pytauri/src/pytauri_plugins/dialog/ffi.py
+++ b/python/pytauri/src/pytauri_plugins/dialog/ffi.py
@@ -7,11 +7,13 @@
     You should use the re-exported APIs under the top-level module.
 """
 
+from collections.abc import Sequence
 from enum import Enum, auto
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable, Union, final
+from typing import TYPE_CHECKING, Callable, Optional, Union, final
 
 from pytauri import ImplManager
+from pytauri.ffi._typing import Pyo3Path, StrictPyo3Path
 from pytauri.webview import WebviewWindow
 from typing_extensions import Self, TypeAlias, TypeAliasType, TypedDict, Unpack
 
@@ -22,6 +24,9 @@ from pytauri_plugins import (
 
 __all__ = [
     "DialogExt",
+    "FileDialogBuilder",
+    "FileDialogBuilderArgs",
+    "FilePath",
     "ImplDialogExt",
     "MessageDialogBuilder",
     "MessageDialogBuilderArgs",
@@ -39,6 +44,11 @@ else:
 
 _HasWindowHandleAndHasDisplayHandle: TypeAlias = WebviewWindow
 
+# TODO: unify this type with [tauri_plugin_fs::FilePath]
+# NOTE: In the future, we may use `Union[str, Path]` to distinguish between Union[FilePath::Url, FilePath::Path],
+#       so we use `StrictPyo3Path` instead of `Pyo3Path` here.
+FilePath = TypeAliasType("FilePath", StrictPyo3Path)
+"""[tauri_plugin_dialog::FilePath](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/enum.FilePath.html)"""
 
 if TYPE_CHECKING:
 
@@ -94,17 +104,78 @@ if TYPE_CHECKING:
             **kwargs: Unpack["MessageDialogBuilderArgs"],
         ) -> None: ...
 
+    class FileDialogBuilder:
+        """[tauri_plugin_dialog::FileDialogBuilder](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/struct.FileDialogBuilder.html)"""
+
+        def pick_file(
+            self,
+            handler: Callable[[Optional[FilePath]], object],
+            /,
+            **kwargs: Unpack["FileDialogBuilderArgs"],
+        ) -> None: ...
+
+        def blocking_pick_file(
+            self, /, **kwargs: Unpack["FileDialogBuilderArgs"]
+        ) -> Optional[FilePath]: ...
+
+        def pick_files(
+            self,
+            handler: Callable[[Optional[list[FilePath]]], object],
+            /,
+            **kwargs: Unpack["FileDialogBuilderArgs"],
+        ) -> None: ...
+
+        def blocking_pick_files(
+            self, /, **kwargs: Unpack["FileDialogBuilderArgs"]
+        ) -> Optional[list[FilePath]]: ...
+
+        def pick_folder(
+            self,
+            handler: Callable[[Optional[FilePath]], object],
+            /,
+            **kwargs: Unpack["FileDialogBuilderArgs"],
+        ) -> None: ...
+
+        def blocking_pick_folder(
+            self, /, **kwargs: Unpack["FileDialogBuilderArgs"]
+        ) -> Optional[FilePath]: ...
+
+        def pick_folders(
+            self,
+            handler: Callable[[Optional[list[FilePath]]], object],
+            /,
+            **kwargs: Unpack["FileDialogBuilderArgs"],
+        ) -> None: ...
+
+        def blocking_pick_folders(
+            self, /, **kwargs: Unpack["FileDialogBuilderArgs"]
+        ) -> Optional[list[FilePath]]: ...
+
+        def save_file(
+            self,
+            handler: Callable[[Optional[FilePath]], object],
+            /,
+            **kwargs: Unpack["FileDialogBuilderArgs"],
+        ) -> None: ...
+
+        def blocking_save_file(
+            self, /, **kwargs: Unpack["FileDialogBuilderArgs"]
+        ) -> Optional[FilePath]: ...
+
     @final
     class DialogExt:
         """[tauri_plugin_dialog::DialogExt](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/trait.DialogExt.html)"""
 
         @staticmethod
         def message(slf: "ImplDialogExt", message: str, /) -> MessageDialogBuilder: ...
+        @staticmethod
+        def file(slf: "ImplDialogExt", /) -> FileDialogBuilder: ...
 
 else:
     MessageDialogButtons = _dialog_mod.MessageDialogButtons
     MessageDialogKind = _dialog_mod.MessageDialogKind
     MessageDialogBuilder = _dialog_mod.MessageDialogBuilder
+    FileDialogBuilder = _dialog_mod.FileDialogBuilder
     DialogExt = _dialog_mod.DialogExt
 
 MessageDialogButtonsType = TypeAliasType(
@@ -127,6 +198,18 @@ class MessageDialogBuilderArgs(TypedDict, total=False):
     parent: _HasWindowHandleAndHasDisplayHandle
     buttons: MessageDialogButtonsType
     kind: MessageDialogKind
+
+
+class FileDialogBuilderArgs(TypedDict, total=False):
+    """[tauri_plugin_dialog::FileDialogBuilder](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/struct.FileDialogBuilder.html)"""
+
+    add_filter: tuple[str, Sequence[str]]
+    """(name, extensions)"""
+    set_directory: Pyo3Path
+    set_file_name: str
+    set_parent: _HasWindowHandleAndHasDisplayHandle
+    set_title: str
+    set_can_create_directories: bool
 
 
 ImplDialogExt: TypeAlias = ImplManager

--- a/python/pytauri/src/pytauri_plugins/dialog/ffi.py
+++ b/python/pytauri/src/pytauri_plugins/dialog/ffi.py
@@ -1,0 +1,133 @@
+# ruff: noqa: D102, D106
+
+"""Original FFI interface module.
+
+!!! warning
+    All APIs under this module should not be considered stable.
+    You should use the re-exported APIs under the top-level module.
+"""
+
+from enum import Enum, auto
+from types import ModuleType
+from typing import TYPE_CHECKING, Callable, Union, final
+
+from pytauri import ImplManager
+from pytauri.webview import WebviewWindow
+from typing_extensions import Self, TypeAlias, TypeAliasType, TypedDict, Unpack
+
+from pytauri_plugins import (
+    PLUGIN_DIALOG,
+    _pytauri_plugins_mod,  # pyright: ignore[reportPrivateUsage]
+)
+
+__all__ = [
+    "DialogExt",
+    "ImplDialogExt",
+    "MessageDialogBuilder",
+    "MessageDialogBuilderArgs",
+    "MessageDialogButtons",
+    "MessageDialogButtonsType",
+    "MessageDialogKind",
+]
+
+if PLUGIN_DIALOG:
+    _dialog_mod: ModuleType = _pytauri_plugins_mod.dialog
+else:
+    raise ImportError(
+        "Enable the `plugin-dialog` feature for `pytauri` crate to use this plugin."
+    )
+
+_HasWindowHandleAndHasDisplayHandle: TypeAlias = WebviewWindow
+
+
+if TYPE_CHECKING:
+
+    @final
+    class MessageDialogButtons:
+        """[tauri_plugin_dialog::MessageDialogButtons](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/enum.MessageDialogButtons.html)"""
+
+        @final
+        class Ok: ...
+
+        @final
+        class OkCancel: ...
+
+        @final
+        class YesNo: ...
+
+        @final
+        class OkCustom(tuple[str]):
+            _0: str
+            __match_args__ = ("_0",)
+
+            def __new__(cls, _0: str, /) -> Self: ...
+
+        @final
+        class OkCancelCustom(tuple[str, str]):
+            _0: str
+            _1: str
+            __match_args__ = ("_0", "_1")
+
+            def __new__(cls, _0: str, _1: str, /) -> Self: ...
+
+        # When adding new variants, remember to update `MessageDialogButtonsType`.
+
+    class MessageDialogKind(Enum):
+        """[tauri_plugin_dialog::MessageDialogKind](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/enum.MessageDialogKind.html)"""
+
+        Info = auto()
+        Warning = auto()
+        Error = auto()
+
+    @final
+    class MessageDialogBuilder:
+        """[tauri_plugin_dialog::MessageDialogBuilder](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/struct.MessageDialogBuilder.html)"""
+
+        def blocking_show(
+            self, /, **kwargs: Unpack["MessageDialogBuilderArgs"]
+        ) -> bool: ...
+
+        def show(
+            self,
+            handler: Callable[[bool], object],
+            /,
+            **kwargs: Unpack["MessageDialogBuilderArgs"],
+        ) -> None: ...
+
+    @final
+    class DialogExt:
+        """[tauri_plugin_dialog::DialogExt](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/trait.DialogExt.html)"""
+
+        @staticmethod
+        def message(slf: "ImplDialogExt", message: str, /) -> MessageDialogBuilder: ...
+
+else:
+    MessageDialogButtons = _dialog_mod.MessageDialogButtons
+    MessageDialogKind = _dialog_mod.MessageDialogKind
+    MessageDialogBuilder = _dialog_mod.MessageDialogBuilder
+    DialogExt = _dialog_mod.DialogExt
+
+MessageDialogButtonsType = TypeAliasType(
+    "MessageDialogButtonsType",
+    Union[
+        MessageDialogButtons.Ok,
+        MessageDialogButtons.OkCancel,
+        MessageDialogButtons.YesNo,
+        MessageDialogButtons.OkCustom,
+        MessageDialogButtons.OkCancelCustom,
+    ],
+)
+"""See [MessageDialogButtons][pytauri_plugins.dialog.MessageDialogButtons] for details."""
+
+
+class MessageDialogBuilderArgs(TypedDict, total=False):
+    """[tauri_plugin_dialog::MessageDialogBuilder](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/struct.MessageDialogBuilder.html)"""
+
+    title: str
+    parent: _HasWindowHandleAndHasDisplayHandle
+    buttons: MessageDialogButtonsType
+    kind: MessageDialogKind
+
+
+ImplDialogExt: TypeAlias = ImplManager
+"""The implementers of `DialogExt`."""


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

```py
from pytauri_plugins.dialog import DialogExt, MessageDialogButtons, MessageDialogKind

@commands.command()
async def greet(
    app_handle: AppHandle, webview_window: WebviewWindow
) -> bytes:
    file_dialog_builder = DialogExt.file(app_handle)
    file_dialog_builder.pick_files(
        lambda files: print(f"Files selected: {files}"),
        add_filter=("markdown", ["md"]),
        set_parent=webview_window,
        set_title="Select a Markdown file",
    )

    message_dialog_builder = DialogExt.message(app_handle, "Hello!")
    message_dialog_builder.show(
        lambda is_ok: print(f"Dialog closed with: {is_ok}"),
        parent=webview_window,
        buttons=MessageDialogButtons.OkCancelCustom("ok", "cancel"),
        kind=MessageDialogKind.Info,
    )

    return b"null"
```

![dialog](https://github.com/user-attachments/assets/85cbf9f1-4203-4336-959a-499b3691bcd9)

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
