### PR TITLE
feat(pytauri): support using arbitrary types in `command`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Highlights
+
+#### Support using arbitrary types in `command`
+
+> - [#171](https://github.com/pytauri/pytauri/pull/171) - feat(pytauri): support using arbitrary types in `command`.
+
+See: <https://pytauri.github.io/pytauri/0.7/usage/concepts/ipc/#deserializing-the-body-using-arbitrary-types>
+
+```python
+from pydantic import RootModel
+from pytauri import Commands
+
+commands = Commands()
+
+RootModelStr = RootModel[str]
+
+
+# 😫 ❌
+@commands.command()
+async def old(body: RootModelStr) -> bytes:
+    return b"null"
+
+
+# 😇 ✔
+@commands.command()
+async def new(body: str) -> None:
+    return
+```
+
 ## [0.6.1]
 
 ### Highlights

--- a/docs/usage/concepts/ipc.md
+++ b/docs/usage/concepts/ipc.md
@@ -26,7 +26,7 @@ The currently supported signature pattern is [ArgumentsType][pytauri.ipc.Argumen
 --8<-- "docs_src/concepts/ipc/reg_cmd.py"
 ```
 
-#### Deserializing the Body
+#### Deserializing the Body using `BaseModel`
 
 For the `body` argument, it is of type `bytes`, allowing you to pass binary data such as files between the frontend and backend.
 
@@ -40,6 +40,24 @@ If you use [BaseModel][pydantic.BaseModel]/[RootModel][pydantic.RootModel] as th
 ```python
 --8<-- "docs_src/concepts/ipc/serde_body.py"
 ```
+
+#### Deserializing the Body using arbitrary types
+
+!!! info
+    This is an experimental feature. If we find that it causes more problems than benefits, it may be removed in the future. You may also encounter some bugs—please report them on GitHub issues!
+
+For types like `str`, it would be cumbersome to explicitly declare `#!python StrModel = RootModel[str]` every time. Since pytauri `v0.7`, if you use types other than `bytes`/`BaseModel`/`RootModel` as the type annotation for the `body` parameter or return value, pytauri will automatically convert them to [BaseModel][pydantic.BaseModel]/[TypeAdapter][pydantic.TypeAdapter] behind the scenes.
+
+```python
+--8<-- "docs_src/concepts/ipc/serde_body_as_any.py"
+```
+
+??? tip "Implementation details"
+    These are the current implementation details (which may change in the future). This means you need to pay attention to the [lru_cache][functools.lru_cache] cache missing issue:
+
+    ```python
+    --8<-- "docs_src/concepts/ipc/serde_body_as_any_impl.py"
+    ```
 
 #### Generate Invoke Handler for App
 
@@ -152,4 +170,4 @@ Ref:
 See:
 
 - [pytauri.Listener--examples][]
-- [pytauri.Listener--examples][]
+- [pytauri.Emitter--examples][]

--- a/docs_src/concepts/ipc/accessing_headers.py
+++ b/docs_src/concepts/ipc/accessing_headers.py
@@ -5,6 +5,5 @@ commands = Commands()
 
 
 @commands.command()
-async def command(body: bytes, headers: Headers) -> bytes:  # noqa: ARG001
+async def command(body: bytes, headers: Headers) -> None:  # noqa: ARG001
     print(headers)
-    return b"null"

--- a/docs_src/concepts/ipc/py_channel.py
+++ b/docs_src/concepts/ipc/py_channel.py
@@ -11,11 +11,9 @@ Msg = RootModel[str]
 @commands.command()
 async def command(
     body: JavaScriptChannelId[Msg], webview_window: WebviewWindow
-) -> bytes:
+) -> None:
     channel: Channel[Msg] = body.channel_on(webview_window.as_ref_webview())
 
     # 👇 you should do this as background task, here just keep it simple as a example
     channel.send(b'"message"')
     channel.send_model(Msg("message"))
-
-    return b"null"

--- a/docs_src/concepts/ipc/ret_exec.py
+++ b/docs_src/concepts/ipc/ret_exec.py
@@ -5,5 +5,5 @@ commands = Commands()
 
 
 @commands.command()
-async def command() -> bytes:
+async def command() -> None:
     raise InvokeException("error message")

--- a/docs_src/concepts/ipc/serde_body_as_any.py
+++ b/docs_src/concepts/ipc/serde_body_as_any.py
@@ -1,0 +1,32 @@
+# pyright: reportRedeclaration=none
+# ruff: noqa: F811
+
+from datetime import datetime
+from typing import Optional, Union
+
+from pydantic import RootModel
+from pytauri import AppHandle, Commands
+
+commands = Commands()
+
+StrModel = RootModel[str]
+
+
+# ⭐ OK
+@commands.command()
+async def command(body: datetime, app_handle: AppHandle) -> None: ...
+
+
+# ⭐ OK
+@commands.command()
+async def command(body: Union[str, int]) -> bytes: ...
+
+
+# ⭐ OK
+@commands.command()
+async def command(body: Optional[str]) -> StrModel: ...
+
+
+# ⭐ OK
+@commands.command()
+async def command() -> bool: ...

--- a/docs_src/concepts/ipc/serde_body_as_any_impl.py
+++ b/docs_src/concepts/ipc/serde_body_as_any_impl.py
@@ -1,0 +1,21 @@
+from functools import cache
+from typing import Any, Optional, cast
+
+from pydantic import BaseModel, TypeAdapter
+
+__all__ = ["to_type_adapter"]
+
+
+def to_type_adapter(type_: Any) -> Optional[TypeAdapter[Any]]:
+    if type_ is bytes:
+        return
+    if isinstance(type_, type) and issubclass(type_, BaseModel):
+        return
+
+    type_ = cast(Any, type_)  # make pyright happy
+    return _to_type_adapter(type_)
+
+
+@cache
+def _to_type_adapter(type_: Any) -> TypeAdapter[Any]:
+    return TypeAdapter(type_)

--- a/docs_src/concepts/ipc/serde_body_as_any_impl.py
+++ b/docs_src/concepts/ipc/serde_body_as_any_impl.py
@@ -1,21 +1,21 @@
 from functools import cache
 from typing import Any, Optional, cast
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, RootModel
 
-__all__ = ["to_type_adapter"]
+__all__ = ["to_model"]
 
 
-def to_type_adapter(type_: Any) -> Optional[TypeAdapter[Any]]:
+def to_model(type_: Any) -> Optional[type[RootModel[Any]]]:
     if type_ is bytes:
         return
     if isinstance(type_, type) and issubclass(type_, BaseModel):
         return
 
     type_ = cast(Any, type_)  # make pyright happy
-    return _to_type_adapter(type_)
+    return _to_model_cache(type_)
 
 
 @cache
-def _to_type_adapter(type_: Any) -> TypeAdapter[Any]:
-    return TypeAdapter(type_)
+def _to_model_cache(type_: Any) -> type[RootModel[Any]]:
+    return RootModel[type_]

--- a/docs_src/pytauri_wheel/example/main.py
+++ b/docs_src/pytauri_wheel/example/main.py
@@ -36,8 +36,8 @@ commands = Commands()
 
 
 @commands.command()
-async def greet() -> bytes:
-    return json.dumps(sys.version).encode()
+async def greet() -> str:
+    return sys.version
 
 
 if DEV_SERVER is not None:

--- a/examples/tauri-app-wheel/python/src/tauri_app_wheel/__init__.py
+++ b/examples/tauri-app-wheel/python/src/tauri_app_wheel/__init__.py
@@ -47,7 +47,7 @@ async def timer_task(time_channel: Channel[Time]) -> None:
 @commands.command()
 async def start_timer(
     body: JavaScriptChannelId[Time], webview_window: WebviewWindow
-) -> bytes:
+) -> None:
     time_channel = body.channel_on(webview_window.as_ref_webview())
 
     # NOTE:
@@ -68,7 +68,6 @@ async def start_timer(
     # Or if you use `asyncio`, you can use `asyncio.create_task` derectly,
     # so that you don't need init `task_group`.
     task_group.start_soon(timer_task, time_channel)
-    return b"null"
 
 
 class _CamelModel(BaseModel):
@@ -86,16 +85,11 @@ class Person(_CamelModel):
     name: str
 
 
-Greeting = RootModel[str]
-
-
 @commands.command()
-async def greet(body: Person, webview_window: WebviewWindow) -> Greeting:
+async def greet(body: Person, webview_window: WebviewWindow) -> str:
     webview_window.set_title(f"Hello {body.name}!")
 
-    return Greeting(
-        f"Hello, {body.name}! You've been greeted from Python {sys.version}!"
-    )
+    return f"Hello, {body.name}! You've been greeted from Python {sys.version}!"
 
 
 # Anyio `TaskGroup` can only be created in async context,

--- a/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
+++ b/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
@@ -44,7 +44,7 @@ async def timer_task(time_channel: Channel[Time]) -> None:
 @commands.command()
 async def start_timer(
     body: JavaScriptChannelId[Time], webview_window: WebviewWindow
-) -> bytes:
+) -> None:
     time_channel = body.channel_on(webview_window.as_ref_webview())
 
     # NOTE:
@@ -65,7 +65,6 @@ async def start_timer(
     # Or if you use `asyncio`, you can use `asyncio.create_task` derectly,
     # so that you don't need init `task_group`.
     task_group.start_soon(timer_task, time_channel)
-    return b"null"
 
 
 class _CamelModel(BaseModel):

--- a/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
+++ b/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
@@ -83,13 +83,10 @@ class Person(_CamelModel):
     name: str
 
 
-Greeting = RootModel[str]
-
-
 @commands.command()
 async def greet(
     body: Person, app_handle: AppHandle, webview_window: WebviewWindow
-) -> Greeting:
+) -> str:
     notification_builder = NotificationExt.builder(app_handle)
 
     message_dialog_builder = DialogExt.message(app_handle, f"Hello {body.name}!")
@@ -102,9 +99,7 @@ async def greet(
 
     webview_window.set_title(f"Hello {body.name}!")
 
-    return Greeting(
-        f"Hello, {body.name}! You've been greeted from Python {sys.version}!"
-    )
+    return f"Hello, {body.name}! You've been greeted from Python {sys.version}!"
 
 
 # Anyio `TaskGroup` can only be created in async context,


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

See: <https://pytauri.github.io/pytauri/0.7/usage/concepts/ipc/#deserializing-the-body-using-arbitrary-types>

```python
from pydantic import RootModel
from pytauri import Commands

commands = Commands()

RootModelStr = RootModel[str]


# 😫 ❌
@commands.command()
async def old(body: RootModelStr) -> bytes:
    return b"null"


# 😇 ✔
@commands.command()
async def new(body: str) -> None:
    return
```

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
