### PR TITLE
build: remove upper version constraint for `build-system.requires` deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,24 @@ See <https://pytauri.github.io/pytauri/0.8/usage/tutorial/using-plugins/#all-plu
     "@tauri-apps/plugin-dialog": ^2.3
     ```
 
+### Changed
+
+- [#263](https://github.com/pytauri/pytauri/pull/263) - build: remove upper version constraint for `build-system.requires` deps.
+
+    Updated `pyproject.toml` and docs and to use the following build version constraints:
+
+    ```toml
+    [build-system]
+    requires = [
+        "setuptools >= 80",
+        "setuptools-rust >= 1.11, <2",
+        "setuptools-scm >= 8",
+        "Cython >= 3, <4",
+        "packaging >= 25",
+        "hatchling >= 1.26",
+    ]
+    ```
+
 ### Docs
 
 - [#262](https://github.com/pytauri/pytauri/pull/262) - feat: support json `str | bytes` or `dict` as input for `tauri::Config`.

--- a/docs/usage/tutorial/build-sdist.md
+++ b/docs/usage/tutorial/build-sdist.md
@@ -2,7 +2,7 @@
 
 ## setuptools-rust
 
-When you want to distribute your app in Python format, you need to compile pytauri into a Python extension module file, instead of providing it in memory through `pytauri::standalone::append_ext_mod` in the `main.rs` executable.
+When you want to distribute your app in Python format, you need to compile pytauri into a Python extension module file, instead of providing it in memory through `pytauri::standalone` in the `main.rs` executable.
 
 To do this, we need to use [setuptools-rust](https://github.com/PyO3/setuptools-rust).
 
@@ -10,7 +10,7 @@ Add it to `[build-system]`:
 
 ```toml title="src-tauri/pyproject.toml"
 [build-system]
-requires = ["setuptools>=61", "setuptools-rust==1.*"]
+requires = ["setuptools >= 80", "setuptools-rust >= 1.11, <2"]
 build-backend = "setuptools.build_meta"
 ```
 
@@ -58,7 +58,11 @@ You will also need to tell Setuptools that the Rust files are required to build 
 
     ```toml title="src-tauri/pyproject.toml"
     [build-system]
-    requires = ["setuptools>=61", "setuptools-rust==1.*", "setuptools_scm>=8"]
+    requires = [
+        "setuptools >= 80",
+        "setuptools-rust >= 1.11, <2",
+        "setuptools-scm >= 8",
+      ]
     build-backend = "setuptools.build_meta"
     ```
 

--- a/docs/usage/tutorial/build-standalone-cython.md
+++ b/docs/usage/tutorial/build-standalone-cython.md
@@ -18,7 +18,7 @@ Then, add `Cython` as a build dependency:
 [build-system]
 requires = [
     # ...
-    "Cython>=3",
+    "Cython >= 3, <4",
 ]
 build-backend = "setuptools.build_meta"
 ```

--- a/docs/usage/tutorial/using-pytauri.md
+++ b/docs/usage/tutorial/using-pytauri.md
@@ -44,7 +44,7 @@ dependencies = ["pytauri == 0.7.*"]  # (2)!
 ext_mod = "tauri_app.ext_mod"
 
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools >= 80"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]

--- a/examples/nicegui-app/pyproject.toml
+++ b/examples/nicegui-app/pyproject.toml
@@ -21,7 +21,11 @@ dependencies = [
 ext_mod = "nicegui_app.ext_mod"
 
 [build-system]
-requires = ["setuptools == 80.*", "setuptools-rust == 1.*", "setuptools-scm == 8.*"]
+requires = [
+    "setuptools >= 80",
+    "setuptools-rust >= 1.11, <2",
+    "setuptools-scm >= 8",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]

--- a/examples/tauri-app-wheel/python/pyproject.toml
+++ b/examples/tauri-app-wheel/python/pyproject.toml
@@ -19,7 +19,7 @@ tauri-app-wheel = "tauri_app_wheel:main"
 
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]

--- a/examples/tauri-app/src-tauri/pyproject.toml
+++ b/examples/tauri-app/src-tauri/pyproject.toml
@@ -15,10 +15,10 @@ ext_mod = "tauri_app.ext_mod"
 
 [build-system]
 requires = [
-    "setuptools == 80.*",
-    "setuptools-rust == 1.*",
-    "setuptools-scm == 8.*",
-    "Cython == 3.*",
+    "setuptools >= 80",
+    "setuptools-rust >= 1.11, <2",
+    "setuptools-scm >= 8",
+    "Cython >= 3, <4",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,16 @@ test = [
 ]
 tools = ["pre-commit ==4.2.0"]
 "build-system" = [
-    "setuptools == 80.*",
-    "setuptools-rust == 1.*",
-    "setuptools-scm == 8.*",
-    "Cython == 3.*",
-    "packaging == 25.*",
+    # `setuptools-scm` recommend `setuptools >=80`
+    "setuptools >= 80",
+    # `> 1.11` for free-threading support
+    "setuptools-rust >= 1.11, <2",
+    # `setuptools-scm` recommend `>=8`
+    "setuptools-scm >= 8",
+    # `> 3` for free-threading support
+    "Cython >= 3, <4",
+    # calendar-based versioning (`YY.N`)
+    "packaging >= 25",
 ]
 # NOTE: when adding workspace members,
 # remember to update:

--- a/python/codelldb/pyproject.toml
+++ b/python/codelldb/pyproject.toml
@@ -20,5 +20,5 @@ source = "https://github.com/pytauri/pytauri"
 
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"

--- a/python/pyfuture/pyproject.toml
+++ b/python/pyfuture/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"
 
 [project]

--- a/python/pyo3-utils/pyproject.toml
+++ b/python/pyo3-utils/pyproject.toml
@@ -19,5 +19,5 @@ source = "https://github.com/pytauri/pytauri"
 
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"

--- a/python/pytauri-wheel/pyproject.toml
+++ b/python/pytauri-wheel/pyproject.toml
@@ -29,10 +29,10 @@ ext_mod = "pytauri_wheel.ext_mod"
 
 [build-system]
 requires = [
-    "setuptools == 80.*",
-    "setuptools-rust == 1.*",
-    "setuptools-scm == 8.*",
-    "packaging == 25.*",
+    "setuptools >= 80",
+    "setuptools-rust >= 1.11, <2",
+    "setuptools-scm >= 8",
+    "packaging >= 25",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/python/pytauri/pyproject.toml
+++ b/python/pytauri/pyproject.toml
@@ -33,7 +33,7 @@ source = "https://github.com/pytauri/pytauri"
 # ...
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/tests/pytauri-test/pyproject.toml
+++ b/tests/pytauri-test/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = ["pytauri == 0.1.*", "pydantic == 2.*", "anyio == 4.*"]
 
 
 [build-system]
-requires = ["setuptools == 80.*", "setuptools-scm == 8.*"]
+requires = ["setuptools >= 80", "setuptools-scm >= 8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]

--- a/uv.lock
+++ b/uv.lock
@@ -2009,15 +2009,15 @@ workspaces = [
 
 [package.metadata.requires-dev]
 build-system = [
-    { name = "cython", specifier = "==3.*" },
-    { name = "packaging", specifier = "==25.*" },
-    { name = "setuptools", specifier = "==80.*" },
-    { name = "setuptools-rust", specifier = "==1.*" },
-    { name = "setuptools-scm", specifier = "==8.*" },
+    { name = "cython", specifier = ">=3,<4" },
+    { name = "packaging", specifier = ">=25" },
+    { name = "setuptools", specifier = ">=80" },
+    { name = "setuptools-rust", specifier = ">=1.11,<2" },
+    { name = "setuptools-scm", specifier = ">=8" },
 ]
 dev = [
     { name = "codelldb", editable = "python/codelldb" },
-    { name = "cython", specifier = "==3.*" },
+    { name = "cython", specifier = ">=3,<4" },
     { name = "debugpy", specifier = "==1.*" },
     { name = "griffe-inherited-docstrings", specifier = "==1.1.*" },
     { name = "griffe-pydantic", specifier = "==1.1.*" },
@@ -2031,7 +2031,7 @@ dev = [
     { name = "mkdocs-section-index", specifier = "~=0.3.10" },
     { name = "mkdocstrings", extras = ["python"], specifier = "==0.29.*" },
     { name = "nicegui-app", editable = "examples/nicegui-app" },
-    { name = "packaging", specifier = "==25.*" },
+    { name = "packaging", specifier = ">=25" },
     { name = "pre-commit", specifier = "==4.2.0" },
     { name = "pyfuture", editable = "python/pyfuture" },
     { name = "pyo3-utils", editable = "python/pyo3-utils" },
@@ -2042,9 +2042,9 @@ dev = [
     { name = "pytest-cov", specifier = "==6.2.*" },
     { name = "pytest-timeout", specifier = "==2.4.*" },
     { name = "ruff", specifier = "==0.12.4" },
-    { name = "setuptools", specifier = "==80.*" },
-    { name = "setuptools-rust", specifier = "==1.*" },
-    { name = "setuptools-scm", specifier = "==8.*" },
+    { name = "setuptools", specifier = ">=80" },
+    { name = "setuptools-rust", specifier = ">=1.11,<2" },
+    { name = "setuptools-scm", specifier = ">=8" },
     { name = "tauri-app", editable = "examples/tauri-app/src-tauri" },
     { name = "tauri-app-wheel", editable = "examples/tauri-app-wheel/python" },
     { name = "trio", specifier = "==0.30.0" },
@@ -2326,15 +2326,15 @@ wheels = [
 
 [[package]]
 name = "setuptools-rust"
-version = "1.10.2"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "semantic-version" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/6b/99a1588d826ceb108694ba00f78bc6afda10ed5d72d550ae8f256af1f7b4/setuptools_rust-1.10.2.tar.gz", hash = "sha256:5d73e7eee5f87a6417285b617c97088a7c20d1a70fcea60e3bdc94ff567c29dc", size = 309315, upload-time = "2024-10-02T06:05:06.747Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/92/bf8589b1a2b6107cf9ec8daa9954c0b7620643fe1f37d31d75e572d995f5/setuptools_rust-1.11.1.tar.gz", hash = "sha256:7dabc4392252ced314b8050d63276e05fdc5d32398fc7d3cce1f6a6ac35b76c0", size = 310804, upload-time = "2025-04-04T14:28:10.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/09/3da290ba3934c7003d3a178840579989a7fcfa5bd23f50dd7f2ff27f30e1/setuptools_rust-1.10.2-py3-none-any.whl", hash = "sha256:4b39c435ae9670315d522ed08fa0e8cb29f2a6048033966b6be2571a90ce4f1c", size = 26807, upload-time = "2024-10-02T06:05:04.8Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/01/37e1376f80578882e4f2d451f57d1fb42a599832057a123f57d9f26395c8/setuptools_rust-1.11.1-py3-none-any.whl", hash = "sha256:5eaaddaed268dc24a527ffa659ce56b22d3cf17b781247b779efd611031fe8ea", size = 28120, upload-time = "2025-04-04T14:28:09.564Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

In #220, we pinned the versions of `build-system.requires` in the following commits:

- a6bd06980e28897613e575ed70b5b24e28046c65: to use the `PEP 639` format, see <https://github.com/vllm-project/vllm/pull/17389>
- 64b87cec6fe0861300c769e64502f75a93952693: `setuptools-scm >= 9, <9.2` caused some [build issues](https://github.com/pypa/setuptools-scm/issues/1184)

However, I later learned that setting upper bounds for `build-system` dependencies is not recommended: <https://github.com/pypa/packaging.python.org/pull/1880#discussion_r2217670477>. Instead, we should follow the recommendations in each dependency's documentation when specifying version constraints.

Here are the new version constraints:

- "setuptools >= 80", "setuptools-scm >= 8": [recommended by `setuptools-scm`](https://setuptools-scm.readthedocs.io/en/v9.2.0/)
- "setuptools-rust >= 1.11, <2": no explicit recommendation. *Note, `>= 1.11` introduced support for free-threading*.
- "Cython >= 3, <4": no explicit recommendation, but [`uvloop` uses this](https://github.com/MagicStack/uvloop/blob/96b7ed31afaf02800d779a395591da6a2c8c50e1/pyproject.toml#L61). *Note, `>= 3` introduced support for free-threading*.
- "packaging >= 25": `packaging` uses [calendar-based versioning](https://github.com/pypa/packaging/pull/717), so I chose `v25`, but older versions should also work
- "hatchling >= 1.26": [recommended by `packaging.python.org`](https://github.com/pypa/packaging.python.org/blob/4cfc8b98a2aaaa6b5f7809f9b17f90768f7340fc/source/shared/build-backend-tabs.rst?plain=1#L9)

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
